### PR TITLE
VFXEditor v1.4.0.0

### DIFF
--- a/plugins/VFXEditor/VFXEditor.json
+++ b/plugins/VFXEditor/VFXEditor.json
@@ -3,7 +3,7 @@
     "Name": "VFXEditor",
     "Description": "VFX editor and browser, open with /vfxedit",
     "InternalName": "VFXEditor",
-    "AssemblyVersion": "1.3.2.10",
+    "AssemblyVersion": "1.4.0.0",
     "RepoUrl": "https://github.com/0ceal0t/Dalamud-VFXEditor",
     "ApplicableVersion": "any",
     "Tags": [ "VFX", "AVFX" ],


### PR DESCRIPTION
- Import textures as .atex
- UI improvements
- Rename particles/emitters/etc.
- Workspaces (saves renaming, texture replacements, etc.)
- Remove manipulator and UV preview
- Add missing attributes
- VFX auto-updates when selecting a new source or preview vfx