### PR TITLE
Wordsmith v1.4.0.1

### DIFF
--- a/plugins/Wordsmith/Wordsmith.json
+++ b/plugins/Wordsmith/Wordsmith.json
@@ -2,7 +2,7 @@
   "Author": "Lady Defile",
   "Name": "Wordsmith",
   "InternalName": "Wordsmith",
-  "AssemblyVersion": "1.2.0",
+  "AssemblyVersion": "1.4.0",
   "Description": "Wordsmith is a text editor with roleplayers in mind. It automatically breaks your text up for easy copy/paste, has advanced features, spellcheck, and even a thesaurus.",
   "ApplicableVersion": "any",
   "Tags": [


### PR DESCRIPTION
This is a pretty huge update (functionality-wise, not file size).

# [Changelog](https://github.com/LadyDefile/Wordsmith-DalamudPlugin/pull/12)

## Bug Fixes
* Fixed a fatal bug that would cause a CTD when putting a % symbol.
* Fixed a bug where % would not show in chunk display.

## What users will notice:
* New "Aliases" tab in settings.
* Ability to create header aliases.