### PR TITLE
[Testing] BatteryGauge 0.0.2 Maintenance

### DIFF
--- a/testing/BatteryGauge/BatteryGauge.json
+++ b/testing/BatteryGauge/BatteryGauge.json
@@ -3,7 +3,7 @@
   "Name": "BatteryGauge",
   "InternalName": "BatteryGauge",
   "AssemblyVersion": "0.0.2.0",
-  "Description": "Hey, you! Yes, you! Do you play FFXIV on your laptop or Steam Deck? Or are you so addicted to FFXIV that you have a UPS on your desktop just so you can keep playing through power outages? Then this is the plugin for you!\n\nBatteryGauge adds a battery indicator to your server info bar showing your current battery percentage and expected remaining lifespan (as reported by Windows).",
+  "Description": "Hey, you! Yes, you! Do you play FFXIV on your laptop? Or are you so addicted to FFXIV that you have a UPS on your desktop just so you can keep playing through power outages? Then this is the plugin for you!\n\nBatteryGauge adds a battery indicator to your server info bar showing your current battery percentage and expected remaining lifespan (as reported by Windows).",
   "ApplicableVersion": "any",
   "RepoUrl": "https://github.com/KazWolfe/XIVBatteryGauge/",
   "Tags": [


### PR DESCRIPTION
nofranz

Removing Steam Deck mention from BatteryGauge, as a Wine bug is preventing it from working.