### PR TITLE
Fader Plugin: fixed spelling of internal name in json

### DIFF
--- a/plugins/faderPlugin/faderPlugin.json
+++ b/plugins/faderPlugin/faderPlugin.json
@@ -3,7 +3,7 @@
   "Name": "Fader Plugin",
   "Punchline": "Automatically hides UI elements.",
   "Description": "Lets you automatically hide certain game UI elements based on number of conditions.",
-  "InternalName": "FaderPlugin",
+  "InternalName": "faderPlugin",
   "AssemblyVersion": "1.0.3",
   "RepoUrl": "https://github.com/shdwp/xivFaderPlugin",
   "ApplicableVersion": "any",


### PR DESCRIPTION
Internal name was in different case, and since git doesn't care about the directory name case I just reverted it back to lowercase.