### PR TITLE
Update Chat 2 to 1.17.0

### DIFF
--- a/plugins/ChatTwo/ChatTwo.json
+++ b/plugins/ChatTwo/ChatTwo.json
@@ -2,7 +2,7 @@
   "Author": "ascclemens",
   "Name": "Chat 2",
   "InternalName": "ChatTwo",
-  "AssemblyVersion": "1.16.0.0",
+  "AssemblyVersion": "1.17.0.0",
   "Description": "Chat 2 is a complete rewrite of the in-game chat window as a plugin. It\nsupports:\n\n- Unlimited tabs\n- Tabs that always send to a certain channel\n- More flexible filtering\n- RGB channel colouring\n- Completely variable font size\n- Sidebar tabs\n- Unread counts\n- Screenshot mode (obfuscate names)",
   "ApplicableVersion": "any",
   "RepoUrl": "https://git.annaclemens.io/ascclemens/ChatTwo",


### PR DESCRIPTION
- Added ExtraChat integration
- Fixed a sporadic error on startup when using Axis fonts
- Fixed Novice Network when used with temporary channel keybinds
- Fixed the chat input to behave more like vanilla (save text when pressing Esc, etc.)