### PR TITLE
Update Chat 2 to 1.17.2

### DIFF
--- a/plugins/ChatTwo/ChatTwo.json
+++ b/plugins/ChatTwo/ChatTwo.json
@@ -2,7 +2,7 @@
   "Author": "ascclemens",
   "Name": "Chat 2",
   "InternalName": "ChatTwo",
-  "AssemblyVersion": "1.17.1.0",
+  "AssemblyVersion": "1.17.2.0",
   "Description": "Chat 2 is a complete rewrite of the in-game chat window as a plugin. It\nsupports:\n\n- Unlimited tabs\n- Tabs that always send to a certain channel\n- More flexible filtering\n- RGB channel colouring\n- Completely variable font size\n- Sidebar tabs\n- Unread counts\n- Screenshot mode (obfuscate names)",
   "ApplicableVersion": "any",
   "RepoUrl": "https://git.annaclemens.io/ascclemens/ChatTwo",


### PR DESCRIPTION
- Fixed bugs caused by Dalamud's breaking changes
- Added linkshell names to the channel picker