### PR TITLE
VFXEditor 1.6.4.0

### DIFF
--- a/plugins/VFXEditor/VFXEditor.json
+++ b/plugins/VFXEditor/VFXEditor.json
@@ -4,7 +4,7 @@
     "Punchline": "VFX editor and viewer",
     "Description": "View and modify vfxs, as well as create mods for them. Icon by PAPACHIN",
     "InternalName": "VFXEditor",
-    "AssemblyVersion": "1.6.3.2",
+    "AssemblyVersion": "1.6.4.0",
     "RepoUrl": "https://github.com/0ceal0t/Dalamud-VFXEditor",
     "ApplicableVersion": "any",
     "Tags": [ "VFX", "AVFX" ],


### PR DESCRIPTION
- Fix issues with new Imgui version
- Add node library
- Add new `.vfxedit2` import and export format which preserves node renames
- Fix issue with invalid assembly location
- Add more options to texture import
- UI adjustments
- Add "recent" tab to TMB and PAP selects