### PR TITLE
Validate pluginmaster on push

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -2,7 +2,7 @@ name: Validate PluginMaster
 on:
   push:
     branches-ignore:
-      - master
+      - 'api*'
 
 jobs:
   generate:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,14 @@
+name: Validate PluginMaster
+on:
+  push:
+    branches-ignore:
+      - master
+
+jobs:
+  generate:
+    name: Validate PluginMaster
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v1
+      - name: Run generator
+        run: .\Make-PluginMaster.ps1

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -9,6 +9,6 @@ jobs:
     name: Validate PluginMaster
     runs-on: windows-2019
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Run generator
         run: .\Make-PluginMaster.ps1

--- a/Make-PluginMaster.ps1
+++ b/Make-PluginMaster.ps1
@@ -76,8 +76,6 @@ Foreach-Object {
     $content | add-member -Force -Name "DownloadCount" $dlCount -MemberType NoteProperty
 
     if ($content.CategoryTags -eq $null) {
-    	$content | Select-Object -Property * -ExcludeProperty CategoryTags
-
         $fallbackCategoryTags = $categoryFallbacksMap | Select-Object -ExpandProperty $content.InternalName
         if ($fallbackCategoryTags -ne $null) {
 			$content | add-member -Force -Name "CategoryTags" -value @() -MemberType NoteProperty
@@ -132,8 +130,6 @@ Foreach-Object {
         $content | add-member -Force -Name "IsTestingExclusive" -value "True" -MemberType NoteProperty
 
 		if ($content.CategoryTags -eq $null) {
-			$content | Select-Object -Property * -ExcludeProperty CategoryTags
-
 			$fallbackCategoryTags = $categoryFallbacksMap | Select-Object -ExpandProperty $content.InternalName
 			if ($fallbackCategoryTags -ne $null) {
 				$content | add-member -Force -Name "CategoryTags" -value @() -MemberType NoteProperty

--- a/Make-PluginMaster.ps1
+++ b/Make-PluginMaster.ps1
@@ -41,16 +41,16 @@ Foreach-Object {
     $content = Get-Content $_.FullName | ConvertFrom-Json
 
     $isBanned = Is-Banned -PluginName $content.InternalName -AssemblyVersion $content.AssemblyVersion
-    if ($notInclude.Contains($content.InternalName) -or $isBanned) { 
+    if ($notInclude.Contains($content.InternalName) -or $isBanned) {
     	$content | add-member -Force -Name "IsHide" -value "True" -MemberType NoteProperty
     }
     else
     {
     	$content | add-member -Force -Name "IsHide" -value "False" -MemberType NoteProperty
-        
+
         $newDesc = $content.Description -replace "\n", "<br>"
         $newDesc = $newDesc -replace "\|", "I"
-        
+
         if ($content.DalamudApiLevel -eq $apiLevel) {
             if ($content.RepoUrl) {
                 $table = $table + "| " + $content.Author + " | [" + $content.Name + "](" + $content.RepoUrl + ") | " + $newDesc + " |`n"
@@ -77,7 +77,7 @@ Foreach-Object {
 
     if ($content.CategoryTags -eq $null) {
     	$content | Select-Object -Property * -ExcludeProperty CategoryTags
-    
+
         $fallbackCategoryTags = $categoryFallbacksMap | Select-Object -ExpandProperty $content.InternalName
         if ($fallbackCategoryTags -ne $null) {
 			$content | add-member -Force -Name "CategoryTags" -value @() -MemberType NoteProperty
@@ -86,8 +86,12 @@ Foreach-Object {
     }
 
     $internalName = $content.InternalName
-    
-    $updateDate = git log -1 --pretty="format:%ct" plugins/$internalName/latest.zip
+
+    $path = "plugins/$internalName/latest.zip"
+    if (!($path | Test-Path)) {
+        exit 1;
+    }
+    $updateDate = git log -1 --pretty="format:%ct" $path
     if ($updateDate -eq $null){
         $updateDate = 0;
     }
@@ -95,10 +99,10 @@ Foreach-Object {
 
     $installLink = $dlTemplateInstall -f $internalName, "False"
     $content | add-member -Force -Name "DownloadLinkInstall" $installLink -MemberType NoteProperty
-    
+
     $installLink = $dlTemplateInstall -f $internalName, "True"
     $content | add-member -Force -Name "DownloadLinkTesting" $installLink -MemberType NoteProperty
-    
+
     $updateLink = $dlTemplateUpdate -f "plugins", $internalName
     $content | add-member -Force -Name "DownloadLinkUpdate" $updateLink -MemberType NoteProperty
 
@@ -110,7 +114,7 @@ Foreach-Object {
     $content = Get-Content $_.FullName | ConvertFrom-Json
 
     $isBanned = Is-Banned -PluginName $content.InternalName -AssemblyVersion $content.AssemblyVersion
-    if ($notInclude.Contains($content.InternalName) -or $isBanned) { 
+    if ($notInclude.Contains($content.InternalName) -or $isBanned) {
     	$content | add-member -Force -Name "IsHide" -value "True" -MemberType NoteProperty
     }
     else
@@ -129,7 +133,7 @@ Foreach-Object {
 
 		if ($content.CategoryTags -eq $null) {
 			$content | Select-Object -Property * -ExcludeProperty CategoryTags
-		
+
 			$fallbackCategoryTags = $categoryFallbacksMap | Select-Object -ExpandProperty $content.InternalName
 			if ($fallbackCategoryTags -ne $null) {
 				$content | add-member -Force -Name "CategoryTags" -value @() -MemberType NoteProperty
@@ -138,8 +142,12 @@ Foreach-Object {
 		}
 
         $internalName = $content.InternalName
-        
-        $updateDate = git log -1 --pretty="format:%ct" testing/$internalName/latest.zip
+
+        $path = "testing/$internalName/latest.zip"
+        if (!($path | Test-Path)) {
+            exit 1;
+        }
+        $updateDate = git log -1 --pretty="format:%ct" $path
         if ($updateDate -eq $null){
             $updateDate = 0;
         }
@@ -147,13 +155,13 @@ Foreach-Object {
 
         $installLink = $dlTemplateInstall -f $internalName, "True"
         $content | add-member -Force -Name "DownloadLinkInstall" $installLink -MemberType NoteProperty
-        
+
         $installLink = $dlTemplateInstall -f $internalName, "True"
         $content | add-member -Force -Name "DownloadLinkTesting" $installLink -MemberType NoteProperty
-    
+
         $updateLink = $dlTemplateUpdate -f "plugins", $internalName
         $content | add-member -Force -Name "DownloadLinkUpdate" $updateLink -MemberType NoteProperty
-    
+
         $output.Add($content)
     }
 }


### PR DESCRIPTION
Fixes #2817 by a) bailing out on generation if there's an internalname mismatch and b) trying to generate pluginmaster on all pushes, except to the api branches